### PR TITLE
drop lowSearchText and searchSummary

### DIFF
--- a/lib/pages.js
+++ b/lib/pages.js
@@ -251,6 +251,22 @@ module.exports = function(self) {
       var sortTitle = self.sortify(page.title);
       var highWords = _.uniq(highText.split(/ /));
 
+      /**
+       * Remove these fields, because the lead to errors on pages
+       * where several blog-posts were rendered.
+       *
+       * In our case it was the homepage were all blog-posts were rendered
+       * also some snippets (so called mediagalerys) were rendered on this page.
+       * This lead to a way to long searchSummary and lowSearchText because
+       * all contents of all articles and snippets were involved to this fields.
+       *
+       * Even worse is the fact, that some strings weren't escaped which lead to
+       * a destroyed js on client –> which leads to the fact that no one could
+       * add new pages for example...
+       */
+      lowText = '';
+      searchSummary = '';      
+
       return self.pages.update({ slug: page.slug }, { $set: { sortTitle: sortTitle, highSearchText: highText, highSearchWords: highWords, lowSearchText: lowText, searchSummary: searchSummary } }, callback);
     }
 


### PR DESCRIPTION
```
/**
* Remove these fields, because the lead to errors on pages
* where several blog-posts were rendered.
*
* In our case it was the homepage were all blog-posts were rendered
* also some snippets (so called mediagalerys) were rendered on this page.
* This lead to a way to long searchSummary and lowSearchText because
* all contents of all articles and snippets were involved to this fields.
*
* Even worse is the fact, that some strings weren't escaped which lead to
* a destroyed js on client –> which leads to the fact that no one could
* add new pages for example...
*/
```
